### PR TITLE
fix: allow game message tts when chatMessagesFriendsOnly enabled

### DIFF
--- a/src/main/java/com/ttsplugin/main/TTSPlugin.java
+++ b/src/main/java/com/ttsplugin/main/TTSPlugin.java
@@ -238,7 +238,7 @@ public class TTSPlugin extends Plugin {
 			if (!sender.isEmpty() && ignoreSpam(message, sender) && config.ignoreSpam()) return;
 			if (!config.chatMessages() && !sender.isEmpty()) return;
 			Player player = getPlayerFromUsername(sender);
-			if (config.chatMessagesFriendsOnly() && !player.isFriend()) return;
+			if (player != null && config.chatMessagesFriendsOnly() && !player.isFriend()) return;
 
 			voice = getVoice(sender, player == null ? Gender.UNKNOWN : Gender.get(player.getPlayerComposition().isFemale())).id;
 			distance = player == null ? 0 : client.getLocalPlayer().getWorldLocation().distanceTo(player.getWorldLocation());


### PR DESCRIPTION
Fixes #37

```
java.lang.NullPointerException: Cannot invoke "net.runelite.api.Player.isFriend()" because "player" is null
	at com.ttsplugin.main.TTSPlugin.processMessage(TTSPlugin.java:241)
	at com.ttsplugin.main.TTSPlugin.onChatMessage(TTSPlugin.java:179)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.post(Hooks.java:202)
	at kh.ag(kh.java:14514)
	at ho.ae(ho.java:23)
	at lh.an(lh.java:1947)
	at af.am(af.java:446)
	at la.ag(la.java:61147)
	at dj.ae(dj.java:10565)
	at ij.ac(ij.java:101)
	at client.nm(client.java:3571)
	at client.bj(client.java:1138)
	at ba.aw(ba.java:409)
	at ba.ri(ba.java)
	at ba.run(ba.java:25527)
```
